### PR TITLE
Run coveralls in PHP 5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,12 @@ matrix:
 before_script:
     - composer install --no-interaction --prefer-source
 
-    - if [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then cat ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini >> ./tests/php-unix.ini; fi
-    - if [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then NTESTER_FLAGS="--coverage ./coverage.xml --coverage-src ./Gopay"; else TESTER_FLAGS=""; fi
+    - if [ "$TRAVIS_PHP_VERSION" == "5.4" ]; then cat ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini >> ./tests/php-unix.ini; fi
+    - if [ "$TRAVIS_PHP_VERSION" == "5.4" ]; then NTESTER_FLAGS="--coverage ./coverage.xml --coverage-src ./Gopay"; else TESTER_FLAGS=""; fi
 
 script:
     - vendor/bin/tester tests -s -p php -c tests/php-unix.ini $NTESTER_FLAGS
 
 after_script:
-    - if [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then composer require satooshi/php-coveralls; fi
-    - if [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then php vendor/bin/coveralls -c tests/.coveralls.yml -v; fi 
+    - if [ "$TRAVIS_PHP_VERSION" == "5.4" ]; then composer require satooshi/php-coveralls; fi
+    - if [ "$TRAVIS_PHP_VERSION" == "5.4" ]; then php vendor/bin/coveralls -c tests/.coveralls.yml -v; fi 


### PR DESCRIPTION
This fixes Issue #32 , as satooshi/php-coveralls stopped working in PHP 5.5 & 5.6 for no obvious reason.