### PR TITLE
Composer page name is lowercase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "Markette/Gopay",
+    "name": "markette/gopay",
     "description": "Integrace platebního systému Gopay pro Nette Framework.",
     "keywords": ["nette", "eshop", "payment", "gopay"],
     "homepage": "http://github.com/Markette/Gopay",


### PR DESCRIPTION
When I was adding `Markette/GopayApi` package to Packagist, I've get error:

"The package name Markette/GopayApi is invalid, it should not contain uppercase characters. We suggest using markette/gopay-api instead."

Anyway, see README.md: https://github.com/Markette/Gopay/blob/master/README.md#instalace

There is also `composer require markette/gopay`.

So I've changed it in the composer.json.