### PR TITLE
Configurable possibility to channel on GoPay

### DIFF
--- a/src/Gopay/Extension.php
+++ b/src/Gopay/Extension.php
@@ -48,11 +48,8 @@ class Extension extends CompilerExtension
 				$config['gopayId'],
 				$config['gopaySecretKey'],
 				isset($config['testMode']) ? $config['testMode'] : FALSE,
+				$config['changeChannel'],
 			));
-			
-		if (isset($config['changeChannel'])) {
-			$service->addSetup('setChangeChannel', TRUE);
-		}
 
 		if (isset($config['channels'])) {
 			$constants = ClassType::from('Markette\Gopay\Service');

--- a/src/Gopay/Extension.php
+++ b/src/Gopay/Extension.php
@@ -30,6 +30,7 @@ class Extension extends CompilerExtension
 		'gopayId' => NULL,
 		'gopaySecretKey' => NULL,
 		'testMode' => TRUE,
+		'changeChannel' => TRUE, 
 		'channels' => array(),
 	);
 
@@ -46,7 +47,8 @@ class Extension extends CompilerExtension
 				$driver,
 				$config['gopayId'],
 				$config['gopaySecretKey'],
-				isset($config['testMode']) ? $config['testMode'] : FALSE
+				isset($config['testMode']) ? $config['testMode'] : FALSE,
+				$config['changeChannel'],
 			));
 
 		if (isset($config['channels'])) {

--- a/src/Gopay/Extension.php
+++ b/src/Gopay/Extension.php
@@ -48,8 +48,9 @@ class Extension extends CompilerExtension
 				$config['gopayId'],
 				$config['gopaySecretKey'],
 				isset($config['testMode']) ? $config['testMode'] : FALSE,
-				$config['changeChannel'],
 			));
+			
+		$service->addSetup('setChangeChannel', array($config['changeChannel']));
 
 		if (isset($config['channels'])) {
 			$constants = ClassType::from('Markette\Gopay\Service');

--- a/src/Gopay/Extension.php
+++ b/src/Gopay/Extension.php
@@ -48,8 +48,11 @@ class Extension extends CompilerExtension
 				$config['gopayId'],
 				$config['gopaySecretKey'],
 				isset($config['testMode']) ? $config['testMode'] : FALSE,
-				$config['changeChannel'],
 			));
+			
+		if (isset($config['changeChannel'])) {
+			$service->addSetup('setChangeChannel', TRUE);
+		}
 
 		if (isset($config['channels'])) {
 			$constants = ClassType::from('Markette\Gopay\Service');

--- a/src/Gopay/Service.php
+++ b/src/Gopay/Service.php
@@ -367,7 +367,7 @@ class Service extends Nette\Object
 		if ($this->changeChannel === TRUE) {
 			$channels = array_keys($this->channels);
 		} else {
-			$channels = [$channel];
+			$channels = array($channel);
 		}
 
 		try {

--- a/src/Gopay/Service.php
+++ b/src/Gopay/Service.php
@@ -107,6 +107,9 @@ class Service extends Nette\Object
 	/** @var bool */
 	private $testMode = FALSE;
 
+	/** @var bool */
+	private $changeChannel = TRUE;
+	
 	/** @var string */
 	private $lang = self::LANG_CS;
 
@@ -133,12 +136,13 @@ class Service extends Nette\Object
 	 * @param string
 	 * @param bool
 	 */
-	public function __construct(GopaySoap $soap, $gopayId, $gopaySecretKey, $testMode)
+	public function __construct(GopaySoap $soap, $gopayId, $gopaySecretKey, $testMode, $changeChannel)
 	{
 		$this->soap = $soap;
 		$this->setGopayId($gopayId);
 		$this->setGopaySecretKey($gopaySecretKey);
 		$this->setTestMode($testMode);
+		$this->setChangeChannel($changeChannel);
 	}
 
 
@@ -181,6 +185,12 @@ class Service extends Nette\Object
 	{
 		$this->testMode = (bool) $testMode;
 		GopayConfig::$version = $this->testMode ? GopayConfig::TEST : GopayConfig::PROD;
+		return $this;
+	}
+	
+	public function setChangeChannel($changeChannel = TRUE)
+	{
+		$this->changeChannel = (bool) $changeChannel;
 		return $this;
 	}
 
@@ -353,6 +363,12 @@ class Service extends Nette\Object
 		if (!isset($this->channels[$channel]) && $channel !== self::METHOD_USER_SELECT) {
 			throw new \InvalidArgumentException("Payment channel '$channel' is not supported");
 		}
+		
+		if ($this->changeChannel === TRUE) {
+			$channels = array_keys($this->channels);
+		} else {
+			$channels = [$channel];
+		}
 
 		try {
 			$customer = $payment->getCustomer();
@@ -364,7 +380,7 @@ class Service extends Nette\Object
 				$payment->getVariable(),
 				$this->successUrl,
 				$this->failureUrl,
-				array_keys($this->channels),
+				$channels,
 				$channel,
 				$this->gopaySecretKey,
 				$customer->firstName,

--- a/src/Gopay/Service.php
+++ b/src/Gopay/Service.php
@@ -136,13 +136,12 @@ class Service extends Nette\Object
 	 * @param string
 	 * @param bool
 	 */
-	public function __construct(GopaySoap $soap, $gopayId, $gopaySecretKey, $testMode, $changeChannel)
+	public function __construct(GopaySoap $soap, $gopayId, $gopaySecretKey, $testMode)
 	{
 		$this->soap = $soap;
 		$this->setGopayId($gopayId);
 		$this->setGopaySecretKey($gopaySecretKey);
 		$this->setTestMode($testMode);
-		$this->setChangeChannel($changeChannel);
 	}
 
 

--- a/src/Gopay/Service.php
+++ b/src/Gopay/Service.php
@@ -136,12 +136,13 @@ class Service extends Nette\Object
 	 * @param string
 	 * @param bool
 	 */
-	public function __construct(GopaySoap $soap, $gopayId, $gopaySecretKey, $testMode)
+	public function __construct(GopaySoap $soap, $gopayId, $gopaySecretKey, $testMode, $changeChannel)
 	{
 		$this->soap = $soap;
 		$this->setGopayId($gopayId);
 		$this->setGopaySecretKey($gopaySecretKey);
 		$this->setTestMode($testMode);
+		$this->setChangeChannel($changeChannel);
 	}
 
 


### PR DESCRIPTION
Now you can configure (changeChannel config parameter) a possibility to
allow or deny a change of a payment channel on GoPay gate.