### PR TITLE
Readme: use native inject

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Ty si můžete pomocí `autowiringu` vstříknout do `Presenteru`.
 ```php
 use Markette\Gopay\Service\PaymentService;
 
-/** @var PaymentService @autowire */
+/** @var PaymentService @inject */
 public $paymentService;
 ```
 


### PR DESCRIPTION
Readme uses annotation that is not support by dependencies mentioned in `composer.json`.
This might be really confusing for someone, who needs to use just Gopay.

I'd suggest using `@inject`, or add `Kdyby\Autowire` to `composer.json` and note about it's installation to Readme.

